### PR TITLE
Indifferent hash for blankness attribute lookup

### DIFF
--- a/app/models/concerns/blankness/attributes.rb
+++ b/app/models/concerns/blankness/attributes.rb
@@ -22,7 +22,7 @@ module Blankness
     end
 
     def blank_attribute?(name)
-      blank_attribute_value?(attributes[name.to_s])
+      blank_attribute_value?(attributes.with_indifferent_access[name])
     end
 
     def blank_attribute_value?(value)

--- a/app/models/concerns/blankness/attributes.rb
+++ b/app/models/concerns/blankness/attributes.rb
@@ -22,7 +22,7 @@ module Blankness
     end
 
     def blank_attribute?(name)
-      blank_attribute_value?(attributes[name])
+      blank_attribute_value?(attributes[name.to_s])
     end
 
     def blank_attribute_value?(value)


### PR DESCRIPTION
For some reason, in production RAILS_ENV, symbols do not (always?) work when looking up Mongoid attributes.