### PR TITLE
Add tableized view presenter concern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/europeana/europeana-i18n-ruby.git
-  revision: 3610ab984c2bf7faa0b7591813c1104ffa14fdaf
+  revision: 7e3ee2860c41b317e1cfc5799d75a4383ae877a0
   branch: develop
   specs:
     europeana-i18n (0.0.1)

--- a/app/presenters/concerns/tableized_view.rb
+++ b/app/presenters/concerns/tableized_view.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+##
+# Helpers for presenters working with HTML tables in the styleguide
+module TableizedView
+  extend ActiveSupport::Concern
+
+  def table_cell(content, **options)
+    { content: content }.merge(options).reverse_merge(row_link: true)
+  end
+end

--- a/app/presenters/contributions/index.rb
+++ b/app/presenters/contributions/index.rb
@@ -2,6 +2,8 @@
 
 module Contributions
   class Index < ApplicationPresenter
+    include TableizedView
+
     def content
       mustache[:content] ||= begin
         {
@@ -65,11 +67,11 @@ module Contributions
 
     def contribution_table_row_data_cells(contribution)
       [
-        contribution.ore_aggregation.edm_aggregatedCHO&.dc_contributor_agent&.foaf_name&.join('; '),
-        contribution.ore_aggregation.edm_aggregatedCHO&.dc_identifier&.join('; '),
-        contribution.created_at,
-        t(contribution.aasm_state, scope: 'contribute.contributions.states'),
-        contribution.has_media? ? '✔' : '✘'
+        table_cell(contribution.ore_aggregation.edm_aggregatedCHO&.dc_contributor_agent&.foaf_name&.join('; ')),
+        table_cell(contribution.ore_aggregation.edm_aggregatedCHO&.dc_identifier&.join('; ')),
+        table_cell(contribution.created_at),
+        table_cell(t(contribution.aasm_state, scope: 'contribute.contributions.states')),
+        table_cell(contribution.has_media? ? '✔' : '✘')
       ]
     end
   end


### PR DESCRIPTION
A regression has been introduced where the styleguide gem has been updated for another required change, but bringing with it breaking changes to table cell data structure on /contributions not yet merged from #109.

This branch just introduces the changes from #109 for hashes of table cell data on /contributions without the events UI features.