### PR TITLE
Formalise uploaded media naming

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -11,10 +11,8 @@ class MediaController < ApplicationController
 
   def redirect_location(web_resource)
     case params[:size]
-    when 'w200'
-      web_resource.media.url(:thumb_200x200)
-    when 'w400'
-      web_resource.media.url(:thumb_400x400)
+    when 'w200', 'w400'
+      web_resource.media.url(params[:size].to_sym)
     else
       web_resource.media_url
     end

--- a/app/jobs/thumbnail_job.rb
+++ b/app/jobs/thumbnail_job.rb
@@ -5,6 +5,6 @@ class ThumbnailJob < ApplicationJob
 
   def perform(web_resource_id)
     web_resource = EDM::WebResource.find(web_resource_id)
-    web_resource.media.recreate_versions!(:thumb_400x400, :thumb_200x200)
+    web_resource.media.recreate_versions!(:w400, :w200)
   end
 end

--- a/app/models/edm/web_resource.rb
+++ b/app/models/edm/web_resource.rb
@@ -133,6 +133,15 @@ module EDM
       end
     end
 
+    def media_filename
+      ext = media&.filename_extension.nil? ? '' : ".#{media.filename_extension}"
+      "#{media_basename}#{ext}"
+    end
+
+    def media_basename
+      uuid || id.to_s
+    end
+
     def media_blank?
       media.identifier.nil?
     end
@@ -151,7 +160,7 @@ module EDM
 
     def media_size_permitted
       limit = MAX_MEDIA_SIZE
-      if media.file.size > limit
+      if (media&.file&.size || 0) > limit
         errors.add(:media, I18n.t('contribute.form.validation.media_size', size: ::ApplicationController.helpers.number_to_human_size(limit)))
       end
     end

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -8,42 +8,33 @@ class MediaUploader < CarrierWave::Uploader::Base
   storage :fog
   cache_storage :fog
 
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
-  def store_dir
-    @store_dir ||= "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
-  end
-
   process :set_content_type
 
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
-  # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
-
-  # Create different versions of your uploaded files:
-  version :thumb_400x400, if: :supports_thumbnail? do
-    process jpg_and_scale: [400, 400]
+  version :w400, if: :supports_thumbnail? do
+    process jpg_and_scale: [400]
     def full_filename(_for_file)
-      'thumbnail_400x400.jpg'
+      model.media_basename + '.w400.jpg'
     end
   end
 
-  version :thumb_200x200, if: :supports_thumbnail? do
-    process jpg_and_scale: [200, 200]
+  version :w200, if: :supports_thumbnail? do
+    process jpg_and_scale: [200]
     def full_filename(_for_file)
-      'thumbnail_200x200.jpg'
+      model.media_basename + '.w200.jpg'
     end
+  end
+
+  # Always store files in object storage root directory
+  def store_dir
+    nil
+  end
+
+  def filename
+    model.media_filename
+  end
+
+  def filename_extension
+    MIME::Types[file&.content_type]&.first&.preferred_extension || 'tmp'
   end
 
   def move_to_cache
@@ -60,28 +51,15 @@ class MediaUploader < CarrierWave::Uploader::Base
       picture.content_type.match(%r(\Aimage/))
   end
 
-  def jpg_and_scale(size_x = 400, size_y = 400)
+  def jpg_and_scale(size_x = nil, size_y = nil)
     manipulate! do |img|
       img.format('jpg').resize("#{size_x}x#{size_y}")
     end
   end
 
-  # Add a white list of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
-
-  # Override the filename of the uploaded files:
-  # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
-
   ##
   # This overrides the default content_type which is based only on the file extension.
   # Instead this sets the content_type by making a system call to inspect the mime-type.
-  #
   def set_content_type
     file_content_type = `file --b --mime-type '#{path}'`.strip
     if file.respond_to?(:content_type=)

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MediaController do
     let(:params) { { uuid: uuid } }
     let(:web_resource) do
       create(:edm_web_resource).tap do |web_resource|
-        web_resource.media.recreate_versions!(:thumb_400x400, :thumb_200x200)
+        web_resource.media.recreate_versions!(:w400, :w200)
       end
     end
 
@@ -29,13 +29,13 @@ RSpec.describe MediaController do
 
         context 'with size=w200' do
           let(:params) { { uuid: uuid, size: 'w200' } }
-          let(:location) { web_resource.media.url(:thumb_200x200) }
+          let(:location) { web_resource.media.url(:w200) }
           it_behaves_like 'HTTP 303 status'
         end
 
         context 'with size=w400' do
           let(:params) { { uuid: uuid, size: 'w400' } }
-          let(:location) { web_resource.media.url(:thumb_400x400) }
+          let(:location) { web_resource.media.url(:w400) }
           it_behaves_like 'HTTP 303 status'
         end
       end

--- a/spec/jobs/thumbnail_job_spec.rb
+++ b/spec/jobs/thumbnail_job_spec.rb
@@ -1,40 +1,31 @@
 # frozen_string_literal: true
 
 RSpec.describe ThumbnailJob do
-  let(:web_resource) { build(:edm_web_resource) }
-
   it { is_expected.to be_processed_in :thumbnails }
 
-  context 'for edm_isShownBy' do
-    before do
-      web_resource.save # persist the edm_web_resource
-    end
-    after do
-      web_resource.delete
-    end
-    context 'for an image file' do
-      it 'uploads 200x200 and 400x400 thumbnails' do
-        media = web_resource.media
-        media.retrieve_from_store!('image.jpg') # reload the stored versions
-        expect(media.thumb_200x200.file).to_not exist
-        expect(media.thumb_400x400.file).to_not exist
-        subject.perform(web_resource.id.to_s)
-        expect(media.thumb_200x200.file).to exist
-        expect(media.thumb_400x400.file).to exist
-      end
-    end
+  context 'for an image file' do
+    let(:web_resource) { create(:edm_web_resource) }
 
-    context 'for a non-image file' do
+    it 'generates w200 and w400 thumbnails' do
+      media = web_resource.media
+      media.retrieve_from_store!(media.filename) # reload the stored versions
+      expect(media.w200.file).to_not exist
+      expect(media.w400.file).to_not exist
+      subject.perform(web_resource.id.to_s)
+      expect(media.w200.file).to exist
+      expect(media.w400.file).to exist
+    end
+  end
 
-      let(:web_resource) {  build(:edm_web_resource, :audio_media) }
+  context 'for a non-image file' do
+    let(:web_resource) { create(:edm_web_resource, :audio_media) }
 
-      it 'does NOT upload thumbnails' do
-        subject.perform(web_resource.id.to_s)
-        media = web_resource.media
-        media.retrieve_from_store!('audio.mp3') # reload the stored versions
-        expect(media.thumb_200x200.file).to_not be_present
-        expect(media.thumb_400x400.file).to_not be_present
-      end
+    it 'does NOT generate thumbnails' do
+      subject.perform(web_resource.id.to_s)
+      media = web_resource.media
+      media.retrieve_from_store!('audio.mp3') # reload the stored versions
+      expect(media.w200.file).to_not be_present
+      expect(media.w400.file).to_not be_present
     end
   end
 end

--- a/spec/models/edm/web_resource_spec.rb
+++ b/spec/models/edm/web_resource_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe EDM::WebResource do
     it { is_expected.to_not match(%r(text/xml)) }
   end
 
-  describe 'mimetype validation' do
+  describe 'mime type validation' do
     let(:edm_web_resource) do
       build(:edm_web_resource).tap do |wr|
         allow(wr.media).to receive(:content_type) { mime_type }
@@ -110,8 +110,11 @@ RSpec.describe EDM::WebResource do
       end
     end
     let(:file) { double('fake_file', size: 4000000) }
+    before do
+      allow(file).to receive(:content_type) { mime_type }
+    end
 
-    context 'when the mimetype is invalid' do
+    context 'when the mime type is valid' do
       let(:mime_type) { 'image/jpeg' }
       it 'should call remove_media!' do
         expect(edm_web_resource).to_not receive(:remove_media!)
@@ -119,7 +122,7 @@ RSpec.describe EDM::WebResource do
       end
     end
 
-    context 'when the mimetype is invalid' do
+    context 'when the mime type is invalid' do
       let(:mime_type) { 'video/x-ms-wmv' }
       it 'should call remove_media!' do
         expect(edm_web_resource).to receive(:remove_media!)

--- a/spec/system/migration_contribution_submittal_and_retrieval_spec.rb
+++ b/spec/system/migration_contribution_submittal_and_retrieval_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'Migration contribution submittal and retrieval', sidekiq: true d
 
         # Check for thumbnails
         [200, 400].each do |dimension|
-          thumb_sym = "thumb_#{dimension}x#{dimension}".to_sym
+          thumb_sym = "w#{dimension}".to_sym
           thumbnail_url =  webresource.media.url(thumb_sym)
 
           # Ensure thumbnail is retrievable over http.


### PR DESCRIPTION
* All stored in object storage root directory
* Filename base taken from web resource UUID
* Filename extension set from `MIME::Types` preferred extension
* Thumbnails having "w200" or "w400" between UUID and extension
* Thumbnail processing adjusted to enforce 200px or 400px *width*