### PR TITLE
Image height & width as x-amz-meta headers

### DIFF
--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -25,7 +25,7 @@ class MediaUploader < CarrierWave::Uploader::Base
   end
 
   def self.image?(file)
-    file.content_type.present? && # content_type will be false if image is removed
+    file&.content_type.present? && # content_type will be false if image is removed
       !file.content_type.match(%r(\Aimage/)).nil?
   end
 
@@ -51,10 +51,10 @@ class MediaUploader < CarrierWave::Uploader::Base
   end
 
   def fog_attributes
-    super.tap do |attributes|
+    super.dup.tap do |attributes|
       if image? && changed?
-        attributes['x-amz-meta-image-width'] ||= image.width.to_s
-        attributes['x-amz-meta-image-height'] ||= image.height.to_s
+        attributes['x-amz-meta-image-width'] = image.width.to_s
+        attributes['x-amz-meta-image-height'] = image.height.to_s
       end
     end
   end

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -51,12 +51,10 @@ class MediaUploader < CarrierWave::Uploader::Base
   end
 
   def fog_attributes
-    @fog_attributes ||= begin
-      super.tap do |attributes|
-        if image? && changed?
-          attributes['x-amz-meta-image-width'] ||= image.width.to_s
-          attributes['x-amz-meta-image-height'] ||= image.height.to_s
-        end
+    super.tap do |attributes|
+      if image? && changed?
+        attributes['x-amz-meta-image-width'] ||= image.width.to_s
+        attributes['x-amz-meta-image-height'] ||= image.height.to_s
       end
     end
   end

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -24,6 +24,11 @@ class MediaUploader < CarrierWave::Uploader::Base
     end
   end
 
+  def self.image?(file)
+    file.content_type.present? && # content_type will be false if image is removed
+      !file.content_type.match(%r(\Aimage/)).nil?
+  end
+
   # Always store files in object storage root directory
   def store_dir
     nil
@@ -45,10 +50,31 @@ class MediaUploader < CarrierWave::Uploader::Base
     true
   end
 
+  def fog_attributes
+    @fog_attributes ||= begin
+      super.tap do |attributes|
+        if image? && changed?
+          attributes['x-amz-meta-image-width'] ||= image.width.to_s
+          attributes['x-amz-meta-image-height'] ||= image.height.to_s
+        end
+      end
+    end
+  end
+
+  def changed?
+    model.send(:"#{mounted_as}_changed?")
+  end
+
+  def image?
+    self.class.image?(file)
+  end
+
+  def image
+    @image ||= MiniMagick::Image.open(url)
+  end
+
   def supports_thumbnail?(picture)
-    model.persisted? &&
-      picture&.content_type.present? && # content_type will be false if image is removed
-      picture.content_type.match(%r(\Aimage/))
+    model.persisted? && self.class.image?(picture)
   end
 
   def jpg_and_scale(size_x = nil, size_y = nil)

--- a/app/uploaders/media_uploader.rb
+++ b/app/uploaders/media_uploader.rb
@@ -96,6 +96,6 @@ class MediaUploader < CarrierWave::Uploader::Base
   end
 
   def blank?
-    super || model.remove_media?
+    super || model.send(:"remove_#{mounted_as}?")
   end
 end

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe MediaController do
     let(:action) { proc { get :show, params: params } }
     let(:params) { { uuid: uuid } }
     let(:web_resource) do
-      create(:edm_web_resource).tap do |web_resource|
+      create(:edm_web_resource, :image_media).tap do |web_resource|
         web_resource.media.recreate_versions!(:w400, :w200)
       end
     end

--- a/spec/factories/edm/web_resource.rb
+++ b/spec/factories/edm/web_resource.rb
@@ -2,10 +2,12 @@
 
 FactoryBot.define do
   factory :edm_web_resource, class: EDM::WebResource do
-    media { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'support', 'media', 'image.jpg'), 'image/jpeg') }
     edm_rights { build(:cc_license) }
+    trait :image_media do
+      media { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'support', 'media', 'image.jpg'), 'image/jpeg') }
+    end
     trait :audio_media do
-      media { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'support', 'media', 'audio.mp3'), 'audio/mp3') }
+      media { Rack::Test::UploadedFile.new(Rails.root.join('spec', 'support', 'media', 'audio.mp3'), 'audio/mpeg') }
     end
   end
 end

--- a/spec/factories/ore/aggregation.rb
+++ b/spec/factories/ore/aggregation.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     edm_ugc 'true'
     trait :published do
       edm_aggregatedCHO { build(:edm_provided_cho, :published) }
+      edm_isShownBy { build(:edm_web_resource, :image_media) }
     end
   end
 end

--- a/spec/jobs/thumbnail_job_spec.rb
+++ b/spec/jobs/thumbnail_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ThumbnailJob do
   it { is_expected.to be_processed_in :thumbnails }
 
   context 'for an image file' do
-    let(:web_resource) { create(:edm_web_resource) }
+    let(:web_resource) { create(:edm_web_resource, :image_media) }
 
     it 'generates w200 and w400 thumbnails' do
       media = web_resource.media

--- a/spec/validators/campaigns/migration_validator_spec.rb
+++ b/spec/validators/campaigns/migration_validator_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Campaigns::MigrationValidator do
       aggregation.edm_aggregatedCHO = build(:edm_provided_cho, dc_title: nil, dc_description: nil)
       aggregation.edm_aggregatedCHO.dc_contributor_agent = build(:edm_agent)
       aggregation.edm_aggregatedCHO.dc_subject_agents << build(:edm_agent)
-      aggregation.edm_isShownBy = build(:edm_web_resource)
-      aggregation.edm_hasViews << build(:edm_web_resource)
+      aggregation.edm_isShownBy = build(:edm_web_resource, :image_media)
+      aggregation.edm_hasViews << build(:edm_web_resource, :audio_media)
     end
   end
   let(:contribution) do


### PR DESCRIPTION
Apply to existing media with:
```ruby
EDM::WebResource.all.each { |wr| next if wr.media_blank?; wr.media = wr.media.file.dup; wr.save! }
```

Inspect the response headers from the S3 object store to see image width and height.